### PR TITLE
Fix sort indicator always ascending after start

### DIFF
--- a/src/gui/playlistsearchdialog.cpp
+++ b/src/gui/playlistsearchdialog.cpp
@@ -28,6 +28,7 @@ PlaylistSearchDialog::PlaylistSearchDialog(QWidget *parent)
   ui->caseCheckBox->setFocusPolicy(Qt::NoFocus);
   ui->searchLineEdit->setFocus();
   ui->searchTableView->setModel(m_model);
+  ui->searchTableView->setSortingEnabled(false);
 
   connect(ui->searchLineEdit, &QLineEdit::textEdited, this,
           &PlaylistSearchDialog::updateSearchFilter);

--- a/src/gui/playlistwidget.cpp
+++ b/src/gui/playlistwidget.cpp
@@ -51,6 +51,18 @@ void PlaylistWidget::setModel(PlaylistModel *playlistModel) {
   //  ui->tableView->setModel(m_playlistModel);
   m_showingFilterModel->setSourceModel(m_showingModel);
   ui->tableView->setModel(m_showingFilterModel);
+  const QString sortHeader = Config::AppConfig::getInstance()
+                                 ->config(CONFIG_PLAYLIST_SORT_HEADER)
+                                 .value.toString();
+  const Qt::SortOrder sortOrder =
+      static_cast<Qt::SortOrder>(Config::AppConfig::getInstance()
+                                     ->config(CONFIG_PLAYLIST_SORT_ORDER)
+                                     .value.toInt());
+  for (int i = 0; i < m_header->headerCount(); i++) {
+    if (m_header->usedHeader(i) == sortHeader) {
+      ui->tableView->horizontalHeader()->setSortIndicator(i, sortOrder);
+    }
+  }
 }
 
 PlayContentPos PlaylistWidget::preContent() const {


### PR DESCRIPTION
* Sync sort indicator order when set model.
* Disable search
dialog
table sorting.

Closes #4

[skip ci]